### PR TITLE
Feat/particle mesh

### DIFF
--- a/Week0v2/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.cpp
+++ b/Week0v2/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.cpp
@@ -3,6 +3,7 @@
 #include "ParticleEmitterInstance.h"
 #include "ParticleHelper.h"
 #include "ParticleLODLevel.h"
+#include "ParticleSpriteEmitterInstance.h"
 #include "TypeData/ParticleModuleTypeDataBase.h"
 
 UParticleLODLevel* UParticleEmitter::GetCurrentLODLevel(FParticleEmitterInstance* Instance) const
@@ -26,7 +27,7 @@ FParticleEmitterInstance* UParticleEmitter::CreateInstance(UParticleSystemCompon
     {
         if (!InComponent)
             return nullptr;
-        Instance = new FParticleEmitterInstance;
+        Instance = new FParticleSpriteEmitterInstance;
         if (!Instance)
             return nullptr;
         Instance->InitParameters(this, InComponent);

--- a/Week0v2/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.cpp
+++ b/Week0v2/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.cpp
@@ -3,6 +3,7 @@
 #include "ParticleEmitterInstance.h"
 #include "ParticleHelper.h"
 #include "ParticleLODLevel.h"
+#include "ParticleMeshEmitterInstance.h"
 #include "ParticleSpriteEmitterInstance.h"
 #include "TypeData/ParticleModuleTypeDataBase.h"
 
@@ -27,7 +28,8 @@ FParticleEmitterInstance* UParticleEmitter::CreateInstance(UParticleSystemCompon
     {
         if (!InComponent)
             return nullptr;
-        Instance = new FParticleSpriteEmitterInstance;
+        //Instance = new FParticleSpriteEmitterInstance;
+        Instance = new FParticleMeshEmitterInstance;
         if (!Instance)
             return nullptr;
         Instance->InitParameters(this, InComponent);

--- a/Week0v2/Engine/Source/Runtime/Engine/Classes/Particles/ParticleLODLevel.h
+++ b/Week0v2/Engine/Source/Runtime/Engine/Classes/Particles/ParticleLODLevel.h
@@ -16,7 +16,7 @@ public:
     
 
     int32 Level = 0;
-    bool bEnabled;
+    bool bEnabled = true;
 
     void AddModule(UParticleModule* InParticleModule);
     void DeleteModule(UParticleModule* InParticleModule);

--- a/Week0v2/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemComponent.cpp
+++ b/Week0v2/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemComponent.cpp
@@ -16,8 +16,8 @@ void UParticleSystemComponent::TickComponent(float DeltaTime)
     {
         Instance->Tick(DeltaTime);
     }
-    // CreateDynamicData();
-    UpdateDynamicData();
+    CreateDynamicData();
+    //UpdateDynamicData();
 }
 
 UParticleSystemComponent::UParticleSystemComponent()

--- a/Week0v2/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemComponent.cpp
+++ b/Week0v2/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemComponent.cpp
@@ -81,7 +81,7 @@ void UParticleSystemComponent::UpdateDynamicData()
         Source.bUseLocalSpace   = false;
 
         // 렌더용 데이터
-        Source.LocalToWorld = Instance->Component->GetWorldMatrix();
+        Source.ComponentLocalToWorld = Instance->Component->GetWorldMatrix();
         Source.ParticleEmitterRenderData = Instance->GetRenderData();
 
         // 3) 렌더러가 사용할 추가 세팅
@@ -193,7 +193,7 @@ void UParticleSystemComponent::CreateDynamicData()
         
         FDynamicEmitterDataBase* NewDynamicEmitterData = NULL;
         FParticleEmitterInstance* EmitterInst = EmitterInstances[EmitterIndex];
-        if (EmitterInst)
+        if (EmitterInst || !EmitterInst->bEnabled || EmitterInst->ActiveParticles == 0)
         {
             // Create a new dynamic data object for this emitter instance
             NewDynamicEmitterData = EmitterInst->GetDynamicData(false);
@@ -202,6 +202,7 @@ void UParticleSystemComponent::CreateDynamicData()
             {
                 //NewDynamicEmitterData->StatID = EmitterInst->SpriteTemplate->GetStatIDRT();
                 NewDynamicEmitterData->bValid = true;
+                NewDynamicEmitterData->bSelected    = false;
                 NewDynamicEmitterData->EmitterIndex = EmitterIndex;
                 NewDynamicEmitterData->EmitterIndex = EmitterIndex;
                 EmitterRenderData.Add(NewDynamicEmitterData);

--- a/Week0v2/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemRender.cpp
+++ b/Week0v2/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemRender.cpp
@@ -1,8 +1,12 @@
 
 #include "LaunchEngineLoop.h"
 #include "ParticleHelper.h"
+#include "Components/Mesh/StaticMesh.h"
 #include "Container/Array.h"
 #include "Math/Matrix.h"
+#include "Renderer/Renderer.h"
+#include "Renderer/VBIBTopologyMapping.h"
+#include "Renderer/RenderPass/ParticleMeshRenderPass.h"
 #include "Renderer/RenderPass/ParticleRenderPass.h"
 
 FVector2D GetParticleSize(const FBaseParticle& Particle, const FDynamicSpriteEmitterReplayDataBase& Source)
@@ -147,27 +151,7 @@ bool FDynamicSpriteEmitterData::GetVertexAndIndexData(void* VertexData,  void* F
 
 		ParticlePosition = Particle.Location;
 		ParticleOldPosition = Particle.OldLocation;
-
-	    // 공전 모듈 계산
-		//ApplyOrbitToPosition(Particle, Source, InLocalToWorld, ParticlePosition, ParticleOldPosition);
-
-	    // 카메라 오프셋 용
 	    
-		// if (Source.CameraPayloadOffset != 0)
-		// {
-		// 	FVector CameraOffset = GetCameraOffsetFromPayload(Source.CameraPayloadOffset, Particle, ParticlePosition, CameraPosition);
-		// 	ParticlePosition += CameraOffset;
-		// 	ParticleOldPosition += CameraOffset;
-		// }
-	    
-	    // 아틀라스 용
-
-		// if (Source.SubUVDataOffset > 0)
-		// {
-		// 	FFullSubUVPayload* SubUVPayload = (FFullSubUVPayload*)(((uint8*)&Particle) + Source.SubUVDataOffset);
-		// 	SubImageIndex = SubUVPayload->ImageIndex;
-		// }
-
 
 		for (uint32 Factor = 0; Factor < InstanceFactor; Factor++)
 		{
@@ -198,13 +182,6 @@ bool FDynamicSpriteEmitterData::GetVertexAndIndexData(void* VertexData, void* Fi
         ParticleCount = Source.MaxDrawCount;
     }
 
-    // Put the camera origin in the appropriate coordinate space.
-    FVector CameraPosition = InCameraPosition;
-    if (Source.bUseLocalSpace)
-    {
-        FMatrix InvSelf = InLocalToWorld.Inverse();
-        CameraPosition = InvSelf.TransformPosition(InCameraPosition);
-    }
     
     int32	ParticleIndex;
     
@@ -305,7 +282,7 @@ void FDynamicSpriteEmitterData::ExecuteRender(const FMatrix& ViewProj) const
 
     ParticleOrders.SetNum(ParticleCount);
     SortSpriteParticles(true, SourceData->bUseLocalSpace,ParticleCount, SourceData->DataContainer.ParticleData,
-        SourceData->ParticleStride, SourceData->DataContainer.ParticleIndices, &ViewProj, SourceData->LocalToWorld,ParticleOrders);
+        SourceData->ParticleStride, SourceData->DataContainer.ParticleIndices, &ViewProj, SourceData->ComponentLocalToWorld,ParticleOrders);
 
     
     ID3D11Buffer* VB = SourceData->ParticleEmitterRenderData.VertexBuffer;
@@ -336,6 +313,155 @@ void FDynamicSpriteEmitterData::ExecuteRender(const FMatrix& ViewProj) const
              FEngineLoop::GraphicDevice.DeviceContext->PSSetShaderResources(0, 1, &texture->TextureSRV);
     }
     FEngineLoop::GraphicDevice.DeviceContext->DrawInstanced(4, ParticleCount, 0, 0);
+}
+
+void FDynamicMeshEmitterData::GetInstanceData(void* InstanceData, uint32 InstanceFactor, const TArray<FParticleOrder>* ParticleOrder) const
+{
+    int32 ParticleCount = Source.ActiveParticleCount;
+    if ((Source.MaxDrawCount >= 0) && (ParticleCount > Source.MaxDrawCount))
+    {
+        ParticleCount = Source.MaxDrawCount;
+    }
+
+    
+    int32	ParticleIndex;
+    
+    int32 VertexStride = sizeof(FParticleSpriteVertex);
+    uint8* TempVert = (uint8*)InstanceData;
+    FParticleSpriteVertex* FillVertex;
+    
+    FVector ParticlePosition;
+    FVector ParticleOldPosition;
+    float SubImageIndex = 0.0f;
+
+    const uint8* ParticleData = Source.DataContainer.ParticleData;
+    const uint16* ParticleIndices = Source.DataContainer.ParticleIndices;
+    const TArray<FParticleOrder>* OrderedIndices = ParticleOrder;
+
+
+    for (int32 i = 0; i < ParticleCount; i++)
+    {
+        ParticleIndex = OrderedIndices ? (*OrderedIndices)[i].ParticleIndex : i;
+        DECLARE_PARTICLE_CONST(Particle, ParticleData + Source.ParticleStride * ParticleIndices[ParticleIndex]);
+
+        const FVector2D Size = GetParticleSize(Particle, Source);
+
+        ParticlePosition = Particle.Location;
+        ParticleOldPosition = Particle.OldLocation;
+	    
+
+        for (uint32 Factor = 0; Factor < InstanceFactor; Factor++)
+        {
+            FillVertex = (FParticleSpriteVertex*)TempVert;
+            FillVertex->Position = ParticlePosition;
+            FillVertex->RelativeTime = Particle.RelativeTime;
+            FillVertex->OldPosition = ParticleOldPosition;
+            // Create a floating point particle ID from the counter, map into approximately 0-1
+            //FillVertex->ParticleId = (Particle.Flags & STATE_CounterMask) / 10000.0f;
+            FillVertex->ParticleId = (float)(Particle.Flags) / 10000.0f;
+            FillVertex->Size = FVector2D(GetParticleSizeWithUVFlipInSign(Particle, Size));
+            FillVertex->Rotation = Particle.Rotation;
+            FillVertex->SubImageIndex = SubImageIndex;
+            FillVertex->Color = Particle.Color;
+
+            TempVert += VertexStride;
+        }
+    }
+    return ;
+    
+}
+
+void FDynamicMeshEmitterData::ExecuteRender(const FMatrix& ViewProj) const
+{
+    // 업데이트 전에 sorting
+    // Sort and generate particles for this view.
+    const FDynamicMeshEmitterReplayData* SourceData = &static_cast<const FDynamicMeshEmitterReplayData&>(GetSource());
+    if (!SourceData || SourceData->ActiveParticleCount == 0)
+    {
+        return; // 렌더링할 파티클 없음
+    }
+    
+    int32 ParticleCount = SourceData->ActiveParticleCount;
+    if ((SourceData->MaxDrawCount >= 0) && (ParticleCount > SourceData->MaxDrawCount))
+    {
+        ParticleCount = SourceData->MaxDrawCount;
+    }
+    
+    if (ParticleCount == 0)
+    {
+        return;
+    }
+    
+    if (UMaterial* Material = SourceData->Material)
+    {
+        FParticleMeshRenderPass::UpdateMaterialConstants(Material->GetMaterialInfo());
+        //MaterialResource = MaterialInterface->GetRenderProxy();
+    }
+    
+    TArray<FParticleOrder> ParticleOrders;
+
+    ParticleOrders.SetNum(ParticleCount);
+    SortSpriteParticles(true, SourceData->bUseLocalSpace,ParticleCount, SourceData->DataContainer.ParticleData,
+        SourceData->ParticleStride, SourceData->DataContainer.ParticleIndices, &ViewProj, SourceData->ComponentLocalToWorld,ParticleOrders);
+
+    
+    ID3D11Buffer* InstanceVB = SourceData->ParticleEmitterRenderData.InstanceBuffer;
+
+    D3D11_MAPPED_SUBRESOURCE sub = {};
+    const HRESULT hr = FEngineLoop::GraphicDevice.DeviceContext->Map(InstanceVB, 0,D3D11_MAP_WRITE_DISCARD,0, &sub);
+    if (FAILED(hr))
+    {
+        // 실패 시 메시지 박스 표시
+        std::string errorMessage = "Map failed for Dynamic VertexBuffer type: ";
+        MessageBoxA(nullptr, errorMessage.c_str(), "Error", MB_OK | MB_ICONERROR);
+        return;
+    }
+    GetInstanceData(sub.pData,  1 , &ParticleOrders);
+    FEngineLoop::GraphicDevice.DeviceContext->Unmap(InstanceVB, 0);
+
+
+    const OBJ::FStaticMeshRenderData* renderData = StaticMesh->GetRenderData();
+
+    // VIBuffer Bind
+    const std::shared_ptr<FVBIBTopologyMapping> VBIBTopMappingInfo = FEngineLoop::Renderer.GetVBIBTopologyMapping(renderData->DisplayName);
+    VBIBTopMappingInfo->Bind();
+
+    
+    // // SubSet마다 Material Update 및 Draw
+    // for (int subMeshIndex = 0; subMeshIndex < renderData->MaterialSubsets.Num(); ++subMeshIndex)
+    // {
+    //     const int materialIndex = renderData->MaterialSubsets[subMeshIndex].MaterialIndex;
+    //         
+    //     UpdateMaterialConstants(StaticMeshComp->GetMaterial(materialIndex)->GetMaterialInfo());
+    //
+    //     // index draw
+    //     const uint64 startIndex = renderData->MaterialSubsets[subMeshIndex].IndexStart;
+    //     const uint64 indexCount = renderData->MaterialSubsets[subMeshIndex].IndexCount;
+    //     Graphics.DeviceContext->DrawIndexed(indexCount, startIndex, 0);
+    // }
+
+    
+
+
+    const UINT Stride = sizeof(FParticleSpriteVertex);
+    const UINT Offset = 0;
+    FEngineLoop::GraphicDevice.DeviceContext->IASetVertexBuffers(1, 1, &InstanceVB, &Stride, &Offset);
+    if (Source.Material)
+    {
+        auto texture = GEngineLoop.ResourceManager
+                           .GetTexture(Source
+                                           .Material
+                                           ->GetMaterialInfo()
+                                           .DiffuseTexturePath);
+        if (texture)
+             FEngineLoop::GraphicDevice.DeviceContext->PSSetShaderResources(0, 1, &texture->TextureSRV);
+    }
+    
+    UINT IndexCount = VBIBTopMappingInfo->GetNumIndices();
+    if (IndexCount > 0)
+    {
+         FEngineLoop::GraphicDevice.DeviceContext->DrawIndexedInstanced(IndexCount, ParticleCount, 0, 0, 0);
+    }
 }
 
 /**  소스 데이터가 채워진 후 호출되는 이 이미터의 다이내믹 렌더링 데이터를 초기화합니다.*/

--- a/Week0v2/Engine/Source/Runtime/Engine/ParticleEmitterInstance.cpp
+++ b/Week0v2/Engine/Source/Runtime/Engine/ParticleEmitterInstance.cpp
@@ -87,7 +87,7 @@ void FParticleEmitterInstance::Init()
     IsRenderDataDirty    = true;
 
     FRenderResourceManager* renderResourceManager = GEngineLoop.Renderer.GetResourceManager();
-    ParticleEmitterRenderData.VertexBuffer = renderResourceManager->CreateEmptyDynamicVertexBuffer(sizeof(FParticleSpriteVertex) * MaxActiveParticles);
+    ParticleEmitterRenderData.DynamicInstanceVertexBuffer = renderResourceManager->CreateEmptyDynamicVertexBuffer(sizeof(FParticleSpriteVertex) * MaxActiveParticles);
 }
 
 void FParticleEmitterInstance::Tick(float DeltaTime)

--- a/Week0v2/Engine/Source/Runtime/Engine/ParticleEmitterInstance.h
+++ b/Week0v2/Engine/Source/Runtime/Engine/ParticleEmitterInstance.h
@@ -22,8 +22,8 @@ class UParticleEmitter;
 // 동적 버퍼는 인스턴스에서 계속 업데이트 하기 때문에 이미터가 아니라 인스턴스가 소유
 struct FParticleEmitterRenderData
 {
-    ID3D11Buffer* VertexBuffer = nullptr;
-    ID3D11Buffer* InstanceBuffer = nullptr;
+    ID3D11Buffer* DynamicInstanceVertexBuffer = nullptr; //동적버퍼와 인스턴스버퍼는 용도만 다를 뿐 같은 방식으로 생성됨
+    //ID3D11Buffer* InstanceBuffer = nullptr;
 };
 
 struct FParticleEmitterInstance

--- a/Week0v2/Engine/Source/Runtime/Engine/ParticleEmitterInstance.h
+++ b/Week0v2/Engine/Source/Runtime/Engine/ParticleEmitterInstance.h
@@ -23,6 +23,7 @@ class UParticleEmitter;
 struct FParticleEmitterRenderData
 {
     ID3D11Buffer* VertexBuffer = nullptr;
+    ID3D11Buffer* InstanceBuffer = nullptr;
 };
 
 struct FParticleEmitterInstance

--- a/Week0v2/Engine/Source/Runtime/Engine/ParticleMeshEmitterInstance.cpp
+++ b/Week0v2/Engine/Source/Runtime/Engine/ParticleMeshEmitterInstance.cpp
@@ -1,0 +1,90 @@
+#include "ParticleMeshEmitterInstance.h"
+
+#include "ParticleHelper.h"
+#include "Engine/FLoaderOBJ.h"
+#include "Particles/ParticleEmitter.h"
+
+FParticleMeshEmitterInstance::FParticleMeshEmitterInstance()
+{
+    // TODO 테스트 코드
+
+    FManagerOBJ::CreateStaticMesh("Assets/apple_mid.obj");
+    SetStaticMesh(FManagerOBJ::GetStaticMesh(L"apple_mid.obj"));
+    // FManagerOBJ::CreateStaticMesh("Assets/Primitives/Capsule.obj");
+    // SetStaticMesh(FManagerOBJ::GetStaticMesh(L"Capsule.obj"));
+}
+
+FParticleMeshEmitterInstance::~FParticleMeshEmitterInstance()
+{
+}
+
+FDynamicEmitterReplayDataBase* FParticleMeshEmitterInstance::GetReplayData()
+{
+    if (ActiveParticles <= 0 || !bEnabled)
+    {
+        return nullptr;
+    }
+    FDynamicMeshEmitterReplayData* NewEmitterReplayData = new FDynamicMeshEmitterReplayData();
+    if( NewEmitterReplayData == nullptr )
+        return nullptr; 
+
+    if( !FillReplayData( *NewEmitterReplayData ) )
+    {
+        delete NewEmitterReplayData;
+        return NULL;
+    }
+
+    return NewEmitterReplayData;
+}
+
+FDynamicEmitterDataBase* FParticleMeshEmitterInstance::GetDynamicData(bool bSelected)
+{
+    // It is valid for the LOD level to be NULL here!
+    UParticleLODLevel* LODLevel = SpriteTemplate->GetCurrentLODLevel(this);
+
+    if (IsDynamicDataRequired(LODLevel) == false || !bEnabled)
+    {
+        return NULL;
+    }
+
+
+    FDynamicMeshEmitterData* NewEmitterData = new FDynamicMeshEmitterData();
+
+    // Now fill in the source data
+    if (!FillReplayData(NewEmitterData->Source))
+    {
+        delete NewEmitterData;
+        return NULL;
+    }
+
+    NewEmitterData->StaticMesh = StaticMesh;
+    NewEmitterData->bSelected = bSelected;
+
+    // Setup dynamic render data.  Only call this AFTER filling in source data for the emitter.
+    // NewEmitterData->Init(bSelected);
+
+    return NewEmitterData;
+}
+
+bool FParticleMeshEmitterInstance::FillReplayData(FDynamicEmitterReplayDataBase& DynamicEmitterReplayDataBase)
+{
+    if (ActiveParticles <= 0)
+    {
+        return false;
+    }
+
+    // Call parent implementation first to fill in common particle source data
+    if( !FParticleEmitterInstance::FillReplayData( DynamicEmitterReplayDataBase ) )
+    {
+        return false;
+    }
+
+    DynamicEmitterReplayDataBase.eEmitterType = DET_Mesh;
+
+    FDynamicMeshEmitterReplayData* NewReplayData =
+    static_cast< FDynamicMeshEmitterReplayData* >( &DynamicEmitterReplayDataBase );
+
+    NewReplayData->Material = GetCurrentMaterial();
+
+    return true;
+}

--- a/Week0v2/Engine/Source/Runtime/Engine/ParticleMeshEmitterInstance.h
+++ b/Week0v2/Engine/Source/Runtime/Engine/ParticleMeshEmitterInstance.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "ParticleEmitterInstance.h"
+
+class UStaticMesh;
+
+struct FParticleMeshEmitterInstance : public FParticleEmitterInstance
+{
+    FParticleMeshEmitterInstance();
+    virtual ~FParticleMeshEmitterInstance();
+public:
+    virtual FDynamicEmitterReplayDataBase* GetReplayData() override;
+    virtual FDynamicEmitterDataBase* GetDynamicData(bool bSelected) override;
+    virtual bool FillReplayData(FDynamicEmitterReplayDataBase& DynamicEmitterReplayDataBase) override;
+
+    void SetStaticMesh(UStaticMesh* InStaticMesh) { StaticMesh = InStaticMesh; }
+
+    UStaticMesh* StaticMesh;
+};

--- a/Week0v2/Engine/Source/Runtime/Engine/ParticleSpriteEmitterInstance.cpp
+++ b/Week0v2/Engine/Source/Runtime/Engine/ParticleSpriteEmitterInstance.cpp
@@ -2,6 +2,14 @@
 #include "Particles/ParticleEmitter.h"
 #include "ParticleHelper.h"
 
+FParticleSpriteEmitterInstance::FParticleSpriteEmitterInstance()
+{
+}
+
+FParticleSpriteEmitterInstance::~FParticleSpriteEmitterInstance()
+{
+}
+
 FDynamicEmitterReplayDataBase* FParticleSpriteEmitterInstance::GetReplayData()
 {
     if (ActiveParticles <= 0 || !bEnabled)

--- a/Week0v2/Engine/Source/Runtime/Launch/Define.h
+++ b/Week0v2/Engine/Source/Runtime/Launch/Define.h
@@ -140,7 +140,7 @@ namespace OBJ
 
         FString VBName;
         FString IBName;
-        // ID3D11Buffer* VertexBuffer;
+        // ID3D11Buffer* DynamicInstanceVertexBuffer;
         // ID3D11Buffer* IndexBuffer;
         
         TArray<FObjMaterialInfo> Materials;

--- a/Week0v2/Engine/Source/Runtime/Renderer/RenderPass/ParticleMeshRenderPass.cpp
+++ b/Week0v2/Engine/Source/Runtime/Renderer/RenderPass/ParticleMeshRenderPass.cpp
@@ -125,7 +125,7 @@ void FParticleMeshRenderPass::Execute(std::shared_ptr<FViewportClient> InViewpor
 
 void FParticleMeshRenderPass::ClearRenderObjects()
 {
-    FBaseRenderPass::ClearRenderObjects();
+    ParticleSystemComponents.Empty();
 }
 
 void FParticleMeshRenderPass::UpdateMaterialConstants(const FObjMaterialInfo& MaterialInfo)

--- a/Week0v2/Engine/Source/Runtime/Renderer/RenderPass/ParticleMeshRenderPass.cpp
+++ b/Week0v2/Engine/Source/Runtime/Renderer/RenderPass/ParticleMeshRenderPass.cpp
@@ -1,0 +1,170 @@
+#include "ParticleMeshRenderPass.h"
+
+#include "Define.h"
+#include "LaunchEngineLoop.h"
+#include "ParticleEmitterInstance.h"
+#include "ParticleHelper.h"
+#include "D3D11RHI/CBStructDefine.h"
+#include "Engine/World.h"
+#include "Particles/ParticleModuleRequired.h"
+#include "Particles/ParticleSystemComponent.h"
+#include "Renderer/Renderer.h"
+#include "UnrealEd/EditorViewportClient.h"
+#include "UObject/UObjectIterator.h"
+
+
+FParticleMeshRenderPass::FParticleMeshRenderPass(const FName& InShaderName)
+: FBaseRenderPass(InShaderName)
+{
+}
+
+FParticleMeshRenderPass::~FParticleMeshRenderPass()
+{
+}
+
+void FParticleMeshRenderPass::AddRenderObjectsToRenderPass(UWorld* World)
+{
+    for (UParticleSystemComponent* ParticleSystemComponent : TObjectRange<UParticleSystemComponent>())
+    {
+        if (((ParticleSystemComponent->GetWorld()->WorldType != EWorldType::Editor && ParticleSystemComponent->GetWorld()->WorldType != EWorldType::EditorPreview)) || ParticleSystemComponent->GetWorld() != World)
+        {
+            continue;
+        }
+        
+        ParticleSystemComponents.Add(ParticleSystemComponent);
+    }
+}
+
+void FParticleMeshRenderPass::Prepare(std::shared_ptr<FViewportClient> InViewportClient)
+{
+    FBaseRenderPass::Prepare(InViewportClient);
+    
+    
+    const FRenderer& Renderer = GEngineLoop.Renderer;
+    const FGraphicsDevice& Graphics = GEngineLoop.GraphicDevice;
+
+    Graphics.DeviceContext->OMSetDepthStencilState(Renderer.GetDepthStencilState(EDepthStencilState::LessEqual), 0);
+    Graphics.DeviceContext->RSSetState(Renderer.GetRasterizerState(ERasterizerState::SolidNone));
+    Graphics.DeviceContext->OMSetBlendState(nullptr, nullptr, 0xffffffff); // 블렌딩 상태 설정, 기본 블렌딩 상태임
+    FEngineLoop::GraphicDevice.DeviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST); // 삼각형 리스트로 설정
+    
+
+    
+    // RTVs 배열의 유효성을 확인합니다.
+    const auto CurRTV = Graphics.GetCurrentRenderTargetView();
+    if (CurRTV != nullptr)
+    {
+        Graphics.DeviceContext->OMSetRenderTargets(1, &CurRTV, Graphics.GetCurrentWindowData()->DepthStencilView); // 렌더 타겟 설정
+    }
+    else
+    {
+        // RTVs[0]이 nullptr인 경우에 대한 처리
+        // 예를 들어, 기본 렌더 타겟을 설정하거나 오류를 기록할 수 있습니다.
+        // Graphics.DeviceContext->OMSetRenderTargets(1, &Graphics.FrameBufferRTV, Graphics.DepthStencilView);
+    }
+
+    ID3D11SamplerState* linearSampler = Renderer.GetSamplerState(ESamplerType::Linear);
+    Graphics.DeviceContext->PSSetSamplers(static_cast<uint32>(ESamplerType::Linear), 1, &linearSampler);
+}
+
+void FParticleMeshRenderPass::Execute(std::shared_ptr<FViewportClient> InViewportClient)
+{
+    FMatrix View = FMatrix::Identity;
+    FMatrix Proj = FMatrix::Identity;
+    FMatrix ViewProj = FMatrix::Identity;
+
+    
+
+    FGraphicsDevice& Graphics = GEngineLoop.GraphicDevice;
+    FRenderResourceManager* renderResourceManager = GEngineLoop.Renderer.GetResourceManager();
+
+    std::shared_ptr<FEditorViewportClient> curEditorViewportClient = std::dynamic_pointer_cast<FEditorViewportClient>(InViewportClient);
+    if (curEditorViewportClient != nullptr)
+    {
+        View = curEditorViewportClient->GetViewMatrix();
+        Proj = curEditorViewportClient->GetProjectionMatrix();
+        ViewProj = curEditorViewportClient->GetViewProjectionMatrix();
+    }
+
+    FPerFrameConstants PerFrameConstants;
+    
+    PerFrameConstants.ViewMatrix = View;
+    PerFrameConstants.ProjectionMatrix = Proj;
+    
+    USceneComponent* overrideComp = curEditorViewportClient->GetOverrideComponent();
+    if (overrideComp)
+    {
+        PerFrameConstants.CameraWorldPosition = overrideComp->GetWorldLocation();
+    }
+    else
+    {
+        PerFrameConstants.CameraWorldPosition = curEditorViewportClient->ViewTransformPerspective.GetLocation();
+    }
+
+    
+    PerFrameConstants.CameraUpVector = curEditorViewportClient->ViewTransformPerspective.GetUpVector();
+    PerFrameConstants.CameraRightVector = curEditorViewportClient->ViewTransformPerspective.GetRightVector();
+    renderResourceManager->UpdateConstantBuffer("FPerFrameConstants", &PerFrameConstants);
+        
+
+    for (const UParticleSystemComponent* ParticleSystemComponent : ParticleSystemComponents)
+    {
+
+        for (const FDynamicEmitterDataBase* EmitterDataBase : ParticleSystemComponent->EmitterRenderData)
+        {
+            const FDynamicMeshEmitterData* MeshEmitterData = dynamic_cast<const FDynamicMeshEmitterData*>(EmitterDataBase);
+            
+            if (MeshEmitterData)
+            {
+                MeshEmitterData->ExecuteRender(ViewProj);
+            }
+        }
+    }
+
+}
+
+void FParticleMeshRenderPass::ClearRenderObjects()
+{
+    FBaseRenderPass::ClearRenderObjects();
+}
+
+void FParticleMeshRenderPass::UpdateMaterialConstants(const FObjMaterialInfo& MaterialInfo)
+{
+    FGraphicsDevice& Graphics = GEngineLoop.GraphicDevice;
+    FRenderResourceManager* renderResourceManager = GEngineLoop.Renderer.GetResourceManager();
+    
+    FMaterialConstants MaterialConstants;
+    MaterialConstants.DiffuseColor = MaterialInfo.Diffuse;
+    MaterialConstants.TransparencyScalar = MaterialInfo.TransparencyScalar;
+    MaterialConstants.MatAmbientColor = MaterialInfo.Ambient;
+    MaterialConstants.DensityScalar = MaterialInfo.DensityScalar;
+    MaterialConstants.SpecularColor = MaterialInfo.Specular;
+    MaterialConstants.SpecularScalar = MaterialInfo.SpecularScalar;
+    MaterialConstants.EmissiveColor = MaterialInfo.Emissive;
+    //normalScale값 있는데 parse만 하고 constant로 넘기고 있진 않음
+    MaterialConstants.bHasNormalTexture = false;
+    
+    if (MaterialInfo.bHasTexture == true)
+    {
+        const std::shared_ptr<FTexture> texture = GEngineLoop.ResourceManager.GetTexture(MaterialInfo.DiffuseTexturePath);
+        const std::shared_ptr<FTexture> NormalTexture = GEngineLoop.ResourceManager.GetTexture(MaterialInfo.NormalTexturePath);
+        if (texture)
+        {
+            Graphics.DeviceContext->PSSetShaderResources(0, 1, &texture->TextureSRV);
+        }
+        if (NormalTexture)
+        {
+            Graphics.DeviceContext->PSSetShaderResources(1, 1, &NormalTexture->TextureSRV);
+            MaterialConstants.bHasNormalTexture = true;
+        }
+        
+        ID3D11SamplerState* linearSampler = renderResourceManager->GetSamplerState(ESamplerType::Linear);
+        Graphics.DeviceContext->PSSetSamplers(static_cast<uint32>(ESamplerType::Linear), 1, &linearSampler);
+    }
+    else
+    {
+        ID3D11ShaderResourceView* nullSRV[1] = {nullptr};
+        Graphics.DeviceContext->PSSetShaderResources(0, 1, nullSRV);
+    }
+    renderResourceManager->UpdateConstantBuffer(renderResourceManager->GetConstantBuffer(TEXT("FMaterialConstants")), &MaterialConstants);
+}

--- a/Week0v2/Engine/Source/Runtime/Renderer/RenderPass/ParticleMeshRenderPass.h
+++ b/Week0v2/Engine/Source/Runtime/Renderer/RenderPass/ParticleMeshRenderPass.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "FBaseRenderPass.h"
+#include "Container/Array.h"
+#include "Math/Matrix.h"
+#include "Particles/ParticleSystem.h"
+
+class UParticleSystemComponent;
+struct FObjMaterialInfo;
+
+class FParticleMeshRenderPass : public FBaseRenderPass
+{
+public:
+    explicit FParticleMeshRenderPass(const FName& InShaderName);
+    
+    ~FParticleMeshRenderPass() override;
+    
+    void AddRenderObjectsToRenderPass(UWorld* World) override;
+    void Prepare(std::shared_ptr<FViewportClient> InViewportClient) override;
+    void Execute(std::shared_ptr<FViewportClient> InViewportClient) override;
+    void ClearRenderObjects() override;
+
+    static void UpdateMaterialConstants(const FObjMaterialInfo& MaterialInfo);
+
+
+private:
+    TArray<UParticleSystemComponent*> ParticleSystemComponents;
+    
+    class ID3D11Buffer* PerFrameConstantBuffer = nullptr;
+
+    ID3D11InputLayout* InputLayout = nullptr;
+};

--- a/Week0v2/Engine/Source/Runtime/Renderer/RenderPass/ParticleRenderPass.cpp
+++ b/Week0v2/Engine/Source/Runtime/Renderer/RenderPass/ParticleRenderPass.cpp
@@ -50,7 +50,7 @@ void FParticleRenderPass::Prepare(std::shared_ptr<FViewportClient> InViewportCli
     const FRenderer& Renderer = GEngineLoop.Renderer;
     const FGraphicsDevice& Graphics = GEngineLoop.GraphicDevice;
 
-    Graphics.DeviceContext->OMSetDepthStencilState(Renderer.GetDepthStencilState(EDepthStencilState::DepthNone), 0);
+    Graphics.DeviceContext->OMSetDepthStencilState(Renderer.GetDepthStencilState(EDepthStencilState::TranslucentNoDepthWrite), 0);
     Graphics.DeviceContext->RSSetState(Renderer.GetRasterizerState(ERasterizerState::SolidNone));
     Graphics.DeviceContext->OMSetBlendState(Renderer.GetBlendState(EBlendState::AlphaBlend), nullptr, 0xffffffff); // 블렌딩 상태 설정, 기본 블렌딩 상태임
 
@@ -122,9 +122,10 @@ void FParticleRenderPass::Execute(std::shared_ptr<FViewportClient> InViewportCli
 
             for (const FDynamicEmitterDataBase* EmitterDataBase : ParticleSystemComponent->EmitterRenderData)
             {
-                if (EmitterDataBase)
+                const FDynamicSpriteEmitterData* SpriteEmitterData = dynamic_cast<const FDynamicSpriteEmitterData*>(EmitterDataBase);
+                if (SpriteEmitterData)
                 {
-                    EmitterDataBase->ExecuteRender(ViewProj);
+                    SpriteEmitterData->ExecuteRender(ViewProj);
                 }
             }
     }

--- a/Week0v2/Engine/Source/Runtime/Renderer/Renderer.cpp
+++ b/Week0v2/Engine/Source/Runtime/Renderer/Renderer.cpp
@@ -17,6 +17,7 @@
 #include "RenderPass/GizmoRenderPass.h"
 #include "RenderPass/LetterBoxRenderPass.h"
 #include "RenderPass/LineBatchRenderPass.h"
+#include "RenderPass/ParticleMeshRenderPass.h"
 #include "RenderPass/ParticleRenderPass.h"
 #include "RenderPass/SkeletalMeshRenderPass.h"
 #include "RenderPass/StaticMeshRenderPass.h"
@@ -113,6 +114,9 @@ void FRenderer::Initialize(FGraphicsDevice* graphics)
     
     CreateVertexPixelShader(TEXT("ParticleSprite"), nullptr);
     ParticleRenderPass = std::make_shared<FParticleRenderPass>(TEXT("ParticleSprite"));
+    
+    CreateVertexPixelShader(TEXT("ParticleMesh"), nullptr);
+    ParticleMeshRenderPass = std::make_shared<FParticleMeshRenderPass>(TEXT("ParticleMesh"));
     
     CreateVertexPixelShader(TEXT("Final"), nullptr);
     FinalRenderPass = std::make_shared<FFinalRenderPass>(TEXT("Final"));
@@ -283,14 +287,14 @@ void FRenderer::Render(const std::shared_ptr<FEditorViewportClient>& ActiveViewp
             SkeletalRenderPass->Prepare(ActiveViewportClient);
             SkeletalRenderPass->Execute(ActiveViewportClient);
         }
-        ParticleRenderPass->Prepare(ActiveViewportClient);
-        ParticleRenderPass->Execute(ActiveViewportClient);
     }
     
     // if (ActiveViewportClient->GetShowFlag() & static_cast<uint64>(EEngineShowFlags::SF_Particles))
     // {
         ParticleRenderPass->Prepare(ActiveViewportClient);
         ParticleRenderPass->Execute(ActiveViewportClient);
+        ParticleMeshRenderPass->Prepare(ActiveViewportClient);
+        ParticleMeshRenderPass->Execute(ActiveViewportClient);
     //}
 
     if (FogRenderPass->ShouldRender())
@@ -352,9 +356,9 @@ void FRenderer::ClearRenderObjects() const
     LetterBoxRenderPass->ClearRenderObjects();
     FogRenderPass->ClearRenderObjects();
     BlurRenderPass->ClearRenderObjects();
-    ParticleRenderPass->ClearRenderObjects();
     FinalRenderPass->ClearRenderObjects();
     ParticleRenderPass->ClearRenderObjects();
+    ParticleMeshRenderPass ->ClearRenderObjects();
 }
 
 void FRenderer::SetViewMode(const EViewModeIndex evi)
@@ -431,8 +435,8 @@ void FRenderer::AddRenderObjectsToRenderPass(UWorld* World) const
     FogRenderPass->AddRenderObjectsToRenderPass(World);
     BlurRenderPass->AddRenderObjectsToRenderPass(World);
     ParticleRenderPass->AddRenderObjectsToRenderPass(World);
+    ParticleMeshRenderPass->AddRenderObjectsToRenderPass(World);
     FinalRenderPass->AddRenderObjectsToRenderPass(World);
-    ParticleRenderPass->AddRenderObjectsToRenderPass(World);
 }
 
 void FRenderer::MappingVSPSInputLayout(const FName InShaderProgramName, FName VSName, FName PSName, FName InInputLayoutName)

--- a/Week0v2/Engine/Source/Runtime/Renderer/Renderer.h
+++ b/Week0v2/Engine/Source/Runtime/Renderer/Renderer.h
@@ -11,6 +11,7 @@
 #include "RenderPass/FogRenderPass.h"
 #include "RenderPass/ShadowRenderPass.h"
 
+class FParticleMeshRenderPass;
 class FParticleRenderPass;
 class FSkeletalMeshRenderPass;
 class FLetterBoxRenderPass;
@@ -118,6 +119,7 @@ private:
     std::shared_ptr<FLetterBoxRenderPass> LetterBoxRenderPass;
     std::shared_ptr<FBlurRenderPass> BlurRenderPass;
     std::shared_ptr<FParticleRenderPass> ParticleRenderPass;
+    std::shared_ptr<FParticleMeshRenderPass> ParticleMeshRenderPass;
     std::shared_ptr<FFinalRenderPass> FinalRenderPass;
 
     ERasterizerState CurrentRasterizerState = ERasterizerState::SolidBack;

--- a/Week0v2/Shaders/ParticleMeshPixelShader.hlsl
+++ b/Week0v2/Shaders/ParticleMeshPixelShader.hlsl
@@ -1,0 +1,30 @@
+
+#include "ShaderHeaders/GSamplers.hlsli"
+
+
+
+Texture2D gTexture : register(t0);
+
+// 정점 셰이더 출력 구조체 (이전과 동일)
+struct VSOutput
+{
+    float4 PositionPS    : SV_Position;
+    float4 Color         : COLOR0;
+    float2 TexCoord      : TEXCOORD0;
+    float3 NormalWS      : NORMAL0;
+    float3 PositionWS    : TEXCOORD1;
+    float  RelativeTimePS: TEXCOORD2;
+};
+
+// 픽셀 셰이더
+float4 mainPS(VSOutput input) : SV_Target
+{
+    //float4 col = gTexture.Sample(linearSampler, input.TexCoord);
+    // float threshold = 0.01; // 필요한 경우 임계값을 조정
+    // if (col.a < threshold)
+    //     clip(-1); // 픽셀 버리기
+
+    float4 col = float4(1.f,1.f,1.f,1.f);
+    
+    return col;
+}

--- a/Week0v2/Shaders/ParticleMeshPixelShader.hlsl
+++ b/Week0v2/Shaders/ParticleMeshPixelShader.hlsl
@@ -19,12 +19,12 @@ struct VSOutput
 // 픽셀 셰이더
 float4 mainPS(VSOutput input) : SV_Target
 {
-    //float4 col = gTexture.Sample(linearSampler, input.TexCoord);
-    // float threshold = 0.01; // 필요한 경우 임계값을 조정
-    // if (col.a < threshold)
-    //     clip(-1); // 픽셀 버리기
+    float4 col = gTexture.Sample(linearSampler, input.TexCoord);
+     float threshold = 0.01; // 필요한 경우 임계값을 조정
+     if (col.a < threshold)
+         clip(-1); // 픽셀 버리기
 
-    float4 col = float4(1.f,1.f,1.f,1.f);
+    //float4 col = float4(1.f,1.f,1.f,1.f);
     
     return col;
 }

--- a/Week0v2/Shaders/ParticleMeshVertexShader.hlsl
+++ b/Week0v2/Shaders/ParticleMeshVertexShader.hlsl
@@ -21,23 +21,23 @@ cbuffer FPerFrameConstants : register(b2) // b0는 상수 버퍼 슬롯 번호
 
 struct VertexInput_MeshData
 {
-    float4 position : POSITION; // 버텍스 위치
-    float4 color : COLOR; // 버텍스 색상
-    float3 normal : NORMAL; // 버텍스 노멀
-    float3 tangent : TANGENT;
-    float2 texcoord : TEXCOORD;
+    float4 position : SLOT0_POSITION; // 버텍스 위치
+    float4 color : SLOT0_COLOR; // 버텍스 색상
+    float3 normal : SLOT0_NORMAL; // 버텍스 노멀
+    float3 tangent : SLOT0_TANGENT;
+    float2 texcoord : SLOT0_TEXCOORD;
 };
 
 struct VertexInput_InstanceData
 {
-    float3 Position      : INSTANCED_POSITION0;     // 파티클 중심 월드 (또는 로컬) 위치
-    float  RelativeTime  : INSTANCED_TEXCOORD0;   // 상대적 수명 (0~1)
-    float3 OldPosition   : INSTANCED_TEXCOORD1;   // 이전 프레임 위치 (모션 블러용)
-    float  ParticleId    : INSTANCED_TEXCOORD2;   // 파티클 고유 ID
-    float2 Size          : INSTANCED_TEXCOORD3;   // 파티클 2D 크기 (UV 뒤집기 정보 포함 가능)
-    float  Rotation      : INSTANCED_TEXCOORD4;   // 파티클 Z축 회전 (라디안)
-    float  SubImageIndex : INSTANCED_TEXCOORD5;   // SubUV 애니메이션 이미지 인덱스
-    float4 Color         : INSTANCED_COLOR0;      // 파티클 색상 및 알파
+    float3 Position      : SLOT1_INSTANCED_POSITION0;     // 파티클 중심 월드 (또는 로컬) 위치
+    float  RelativeTime  : SLOT1_INSTANCED_TEXCOORD0;   // 상대적 수명 (0~1)
+    float3 OldPosition   : SLOT1_INSTANCED_TEXCOORD1;   // 이전 프레임 위치 (모션 블러용)
+    float  ParticleId    : SLOT1_INSTANCED_TEXCOORD2;   // 파티클 고유 ID
+    float2 Size          : SLOT1_INSTANCED_TEXCOORD3;   // 파티클 2D 크기 (UV 뒤집기 정보 포함 가능)
+    float  Rotation      : SLOT1_INSTANCED_TEXCOORD4;   // 파티클 Z축 회전 (라디안)
+    float  SubImageIndex : SLOT1_INSTANCED_TEXCOORD5;   // SubUV 애니메이션 이미지 인덱스
+    float4 Color         : SLOT1_INSTANCED_COLOR0;      // 파티클 색상 및 알파
 };
 
 // 정점 셰이더 출력 구조체 (이전과 동일)
@@ -62,8 +62,10 @@ VSOutput mainVS(VertexInput_MeshData meshInput, VertexInput_InstanceData instanc
     // 크기 변환 행렬 (X, Y 스케일, Z 스케일은 1.0으로 가정)
     // 또는 instanceInput.Size.x를 균일 스케일로 사용할 수도 있음.
     // 여기서는 instanceInput.Size를 X, Y 스케일로 사용.
-    float particleScaleX = instanceInput.Size.x;
-    float particleScaleY = instanceInput.Size.y;
+    float particleScaleX = 1.f;
+    float particleScaleY = 1.f;
+    //float particleScaleX = instanceInput.Size.x;
+    //float particleScaleY = instanceInput.Size.y;
     // UV 뒤집기 처리 (만약 Size의 부호를 사용한다면)
     // float2 baseUV = meshInput.TexCoordOS; // SubUV 전에 기본 UV
     // if (particleScaleX < 0.0f) { baseUV.x = 1.0f - baseUV.x; particleScaleX = abs(particleScaleX); }

--- a/Week0v2/Shaders/ParticleMeshVertexShader.hlsl
+++ b/Week0v2/Shaders/ParticleMeshVertexShader.hlsl
@@ -1,0 +1,205 @@
+cbuffer FMatrixConstants : register(b1)
+{
+    row_major float4x4 Model;
+    row_major float4x4 ViewProj;
+    row_major float4x4 MInverseTranspose;
+    bool isSelected;
+    float3 pad0;
+};
+
+cbuffer FPerFrameConstants : register(b2) // b0는 상수 버퍼 슬롯 번호
+{
+    row_major matrix ViewMatrix;
+    row_major matrix ProjectionMatrix;
+    float3 CameraWorldPosition;
+    float  Padding0; // 정렬을 위한 패딩
+    float3 CameraUpVector;    // 카메라의 Up 벡터 (빌보딩 시 필요)
+    float  Padding1;
+    float3 CameraRightVector; // 카메라의 Right 벡터 (빌보딩 시 필요)
+    float  Padding2;
+};
+
+struct VertexInput_MeshData
+{
+    float4 position : POSITION; // 버텍스 위치
+    float4 color : COLOR; // 버텍스 색상
+    float3 normal : NORMAL; // 버텍스 노멀
+    float3 tangent : TANGENT;
+    float2 texcoord : TEXCOORD;
+};
+
+struct VertexInput_InstanceData
+{
+    float3 Position      : INSTANCED_POSITION0;     // 파티클 중심 월드 (또는 로컬) 위치
+    float  RelativeTime  : INSTANCED_TEXCOORD0;   // 상대적 수명 (0~1)
+    float3 OldPosition   : INSTANCED_TEXCOORD1;   // 이전 프레임 위치 (모션 블러용)
+    float  ParticleId    : INSTANCED_TEXCOORD2;   // 파티클 고유 ID
+    float2 Size          : INSTANCED_TEXCOORD3;   // 파티클 2D 크기 (UV 뒤집기 정보 포함 가능)
+    float  Rotation      : INSTANCED_TEXCOORD4;   // 파티클 Z축 회전 (라디안)
+    float  SubImageIndex : INSTANCED_TEXCOORD5;   // SubUV 애니메이션 이미지 인덱스
+    float4 Color         : INSTANCED_COLOR0;      // 파티클 색상 및 알파
+};
+
+// 정점 셰이더 출력 구조체 (이전과 동일)
+struct VSOutput
+{
+    float4 PositionPS    : SV_Position;
+    float4 Color         : COLOR0;
+    float2 TexCoord      : TEXCOORD0;
+    float3 NormalWS      : NORMAL0;
+    float3 PositionWS    : TEXCOORD1;
+    float  RelativeTimePS: TEXCOORD2;
+};
+
+// 정점 셰이더 함수
+VSOutput mainVS(VertexInput_MeshData meshInput, VertexInput_InstanceData instanceInput)
+{
+    VSOutput output = (VSOutput)0;
+
+    // 1. 인스턴스별 변환 행렬 구성
+    //    (위치, 크기, Z축 회전만 사용)
+
+    // 크기 변환 행렬 (X, Y 스케일, Z 스케일은 1.0으로 가정)
+    // 또는 instanceInput.Size.x를 균일 스케일로 사용할 수도 있음.
+    // 여기서는 instanceInput.Size를 X, Y 스케일로 사용.
+    float particleScaleX = instanceInput.Size.x;
+    float particleScaleY = instanceInput.Size.y;
+    // UV 뒤집기 처리 (만약 Size의 부호를 사용한다면)
+    // float2 baseUV = meshInput.TexCoordOS; // SubUV 전에 기본 UV
+    // if (particleScaleX < 0.0f) { baseUV.x = 1.0f - baseUV.x; particleScaleX = abs(particleScaleX); }
+    // if (particleScaleY < 0.0f) { baseUV.y = 1.0f - baseUV.y; particleScaleY = abs(particleScaleY); }
+    // 위 UV 뒤집기는 SubUV 계산 시 함께 고려해야 함. 여기서는 크기만 양수로.
+    particleScaleX = abs(particleScaleX);
+    particleScaleY = abs(particleScaleY);
+
+    matrix scaleMatrix = matrix(
+        particleScaleX, 0, 0, 0,
+        0, particleScaleY, 0, 0,
+        0, 0, particleScaleX, 0,          // Z 스케일은 1.0
+        0, 0, 0, 1
+    );
+
+    // Z축 회전 행렬
+    float s = sin(instanceInput.Rotation);
+    float c = cos(instanceInput.Rotation);
+    matrix rotationMatrix = matrix(
+        c,  s, 0, 0,
+       -s,  c, 0, 0,
+        0,  0, 1, 0,
+        0,  0, 0, 1
+    );
+
+    // 이동 변환 행렬
+    // instanceInput.Position이 이미 월드 좌표라면 EmitterWorldMatrix는 Identity
+    // instanceInput.Position이 이미터 로컬 좌표라면 EmitterWorldMatrix를 곱해야 함.
+    // 여기서는 instanceInput.Position을 최종 월드 중심으로 사용한다고 가정.
+    // (만약 instanceInput.Position이 이미터 로컬이면, 먼저 EmitterWorldMatrix로 월드 변환 필요)
+    matrix translationMatrix = matrix(
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        instanceInput.Position.x, instanceInput.Position.y, instanceInput.Position.z, 1
+    );
+
+    // 최종 인스턴스 월드 변환 행렬: Scale -> Rotate -> Translate
+    // (오브젝트 로컬 -> 월드)
+    // HLSL에서 행렬 곱셈은 오른쪽부터 적용되므로 mul(mul(Scale, Rotate), Translate)
+    // 또는, 수학적 순서대로 (v * S * R * T)
+    // 여기서는 v * S * R * T (v는 행벡터, 행렬은 row-major)
+    matrix instanceWorldMatrix = mul(rotationMatrix, scaleMatrix); // 로컬 회전 후 스케일 (또는 스케일 후 회전)
+                                                                  // 보통 Scale -> Rotate 순서가 일반적: mul(scaleMatrix, rotationMatrix)
+    instanceWorldMatrix = mul(instanceWorldMatrix, translationMatrix); // 그 다음 이동
+
+    // 만약 instanceInput.Position이 이미터 로컬 공간이고, EmitterWorldMatrix가 있다면:
+    // matrix instanceLocalMatrix = mul(scaleMatrix, rotationMatrix);
+    // instanceLocalMatrix = mul(instanceLocalMatrix, translationMatrixForLocalOffset); // 만약 로컬 오프셋 이동이 있다면
+    // instanceWorldMatrix = mul(instanceLocalMatrix, EmitterWorldMatrix);
+
+
+    // --- 빌보딩 또는 카메라 페이싱 (선택적, 메시 특성에 따라) ---
+    // 만약 메시 파티클도 스프라이트처럼 항상 카메라를 향해야 한다면 (예: 얇은 판자 모양 메시)
+    // instanceWorldMatrix를 빌보드 행렬로 대체하거나 수정해야 합니다.
+    // 이 경우, 위에서 만든 Scale, Rotation(Z축)은 빌보드 평면 내에서의 크기와 회전이 됩니다.
+    // 예시: 카메라 페이싱 (Y축만 카메라를 향하도록, X축은 월드 Up과 수직)
+    // {
+    //     float3 lookDir = normalize(instanceInput.Position - CameraWorldPosition); // 파티클 -> 카메라
+    //     float3 camRight = normalize(cross(float3(0,1,0)/*WorldUp*/, lookDir)); // 월드 Up과 수직인 Right
+    //     float3 camUp = normalize(cross(lookDir, camRight)); // 실제 Up
+    //
+    //     // 위에서 만든 Scale, Rotation(Z축)을 이 새로운 축에 적용
+    //     matrix billboardRotMatrix = matrix(
+    //         camRight.x, camRight.y, camRight.z, 0,
+    //         camUp.x,    camUp.y,    camUp.z,    0,
+    //         lookDir.x,  lookDir.y,  lookDir.z,  0, // 메시의 로컬 Z가 카메라를 향하도록
+    //         0,          0,          0,          1
+    //     );
+    //     // Z축 중심 회전 적용
+    //     billboardRotMatrix = mul(rotationMatrix, billboardRotMatrix); // 로컬 Z축 회전 후 빌보드
+    //     instanceWorldMatrix = mul(scaleMatrix, billboardRotMatrix);
+    //     instanceWorldMatrix = mul(instanceWorldMatrix, translationMatrix); // 최종 이동
+    // }
+
+
+    // 2. 정점 위치 변환
+    float4 positionOS = float4(meshInput.position);
+    float4 positionWS = mul(positionOS, instanceWorldMatrix); // 로컬 정점 -> 월드 정점
+
+    float4 positionVS = mul(positionWS, ViewMatrix);
+    output.PositionPS = mul(positionVS, ProjectionMatrix);
+    output.PositionWS = positionWS.xyz;
+
+    // 3. 법선 변환
+    float4 normalOS = float4(meshInput.normal,0.0f);
+    // 법선 변환에는 instanceWorldMatrix의 회전/스케일 부분만 사용
+    // (이동 성분 제거, 비균등 스케일 시 역전치 필요)
+    // 간단히는 3x3 부분만 사용
+    matrix instanceWorldRotScaleMatrix = instanceWorldMatrix;
+    instanceWorldRotScaleMatrix._m30_m31_m32 = 0; // 이동 성분 제거 (또는 _41_42_43)
+    instanceWorldRotScaleMatrix._m03_m13_m23_m33 = float4(0,0,0,1); // W 성분 정리
+
+    float4 normalWS_H = mul(normalOS, instanceWorldRotScaleMatrix);
+    output.NormalWS = normalize(normalWS_H.xyz);
+
+    // 4. SubUV 좌표 계산
+    float2 baseMeshUV = meshInput.texcoord;
+    // UV 뒤집기 (만약 Size 부호를 사용한다면, 여기서 baseMeshUV를 수정)
+    if (instanceInput.Size.x < 0.0f) { baseMeshUV.x = 1.0f - baseMeshUV.x; }
+    if (instanceInput.Size.y < 0.0f) { baseMeshUV.y = 1.0f - baseMeshUV.y; }
+    
+    // if (NumSubUVColumns > 0 && NumSubUVRows > 0)
+    // {
+    //     float subImageActualIndex = floor(instanceInput.SubImageIndex);
+    //     float subImageLerp = frac(instanceInput.SubImageIndex);
+    //
+    //     float colA = subImageActualIndex % NumSubUVColumns;
+    //     float rowA = floor(subImageActualIndex / NumSubUVColumns);
+    //     float2 uv_A_Start = float2(colA * InvNumSubUV.x, rowA * InvNumSubUV.y);
+    //     float2 uv_A = uv_A_Start + (baseMeshUV * InvNumSubUV);
+    //
+    //     // 보간을 위한 다음 프레임 인덱스 (간단히 +1, 실제로는 더 복잡한 로직 가능)
+    //     float colB = (subImageActualIndex + 1) % NumSubUVColumns;
+    //     float rowB = floor((subImageActualIndex + 1) / NumSubUVColumns);
+    //     // (만약 애니메이션 끝에 도달하면 어떻게 할지 정의 필요 - 예: 루프, 정지)
+    //     // 여기서는 간단히 다음 인덱스로 가정
+    //     if (subImageActualIndex + 1 >= NumSubUVColumns * NumSubUVRows) { // 애니메이션 끝이면
+    //         colB = colA; // 현재 프레임 유지 (또는 첫 프레임으로 루프)
+    //         rowB = rowA;
+    //     }
+    //
+    //     float2 uv_B_Start = float2(colB * InvNumSubUV.x, rowB * InvNumSubUV.y);
+    //     float2 uv_B = uv_B_Start + (baseMeshUV * InvNumSubUV);
+    //
+    //     output.TexCoord = lerp(uv_A, uv_B, subImageLerp);
+    // }
+    // else
+    {
+        output.TexCoord = baseMeshUV;
+    }
+
+    // 5. 기타 데이터 전달
+    output.Color = instanceInput.Color;
+    output.RelativeTimePS = instanceInput.RelativeTime;
+    // output.ParticleIdPS = instanceInput.ParticleId;
+
+    return output;
+}

--- a/Week0v2/Shaders/ParticleSpriteVertexShader.hlsl
+++ b/Week0v2/Shaders/ParticleSpriteVertexShader.hlsl
@@ -36,6 +36,17 @@ cbuffer FPerFrameConstants : register(b2) // b0는 상수 버퍼 슬롯 번호
 //     // 기타 이미터별 공통 설정 (예: bUseLocalSpace 플래그 등)
 // };
 
+
+struct VSOutput
+{
+    float4 Position    : SV_Position;   // 클립 공간 위치 (필수)
+    float2 TexCoord      : TEXCOORD0;     // UV 좌표
+    float4 Color         : COLOR0;        // 파티클 색상
+    float  RelativeTimePS: TEXCOORD1;
+    float  ParticleIdPS  : TEXCOORD2;
+};
+
+
 struct ParticleVSInput
 {
     float3 Position      : INSTANCED_POSITION0;     // 파티클 중심 월드 (또는 로컬) 위치
@@ -48,14 +59,6 @@ struct ParticleVSInput
     float4 Color         : INSTANCED_COLOR0;      // 파티클 색상 및 알파
 };
 
-struct VSOutput
-{
-    float4 Position    : SV_Position;   // 클립 공간 위치 (필수)
-    float2 TexCoord      : TEXCOORD0;     // UV 좌표
-    float4 Color         : COLOR0;        // 파티클 색상
-    float  RelativeTimePS: TEXCOORD1;
-    float  ParticleIdPS  : TEXCOORD2;
-};
 
 // 정점 셰이더 함수
 VSOutput mainVS(ParticleVSInput input, uint vertexID : SV_VertexID) // SV_VertexID: 0, 1, 2, 3 (Quad의 각 코너)

--- a/Week0v2/Week0v2.vcxproj
+++ b/Week0v2/Week0v2.vcxproj
@@ -374,6 +374,7 @@ xcopy /y /d "$(ProjectDir)Engine\Source\ThirdParty\FBX_SDK\2020.3.7\lib\x64\$(Co
     <ClCompile Include="Engine\Source\Runtime\Renderer\RenderPass\FBaseRenderPass.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\RenderPass\FinalRenderPass.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\RenderPass\FogRenderPass.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Renderer\RenderPass\ParticleMeshRenderPass.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\RenderPass\ParticleRenderPass.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\RenderPass\GizmoRenderPass.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\RenderPass\LetterBoxRenderPass.cpp" />
@@ -446,6 +447,12 @@ xcopy /y /d "$(ProjectDir)Engine\Source\ThirdParty\FBX_SDK\2020.3.7\lib\x64\$(Co
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Animation\CustomAnimInstance\TestAnimInstance.cpp" />
+    <ClCompile Include="Shaders\ParticleMeshPixelShader.hlsl">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="Shaders\ParticleMeshVertexShader.hlsl">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Engine\Source\Editor\UnrealEd\ParticlePreviewUI.h" />
@@ -668,6 +675,7 @@ xcopy /y /d "$(ProjectDir)Engine\Source\ThirdParty\FBX_SDK\2020.3.7\lib\x64\$(Co
     <ClInclude Include="Engine\Source\Runtime\Renderer\RenderPass\FBaseRenderPass.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\RenderPass\FinalRenderPass.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\RenderPass\FogRenderPass.h" />
+    <ClInclude Include="Engine\Source\Runtime\Renderer\RenderPass\ParticleMeshRenderPass.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\RenderPass\ParticleRenderPass.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\RenderPass\GizmoRenderPass.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\RenderPass\LetterBoxRenderPass.h" />

--- a/Week0v2/Week0v2.vcxproj
+++ b/Week0v2/Week0v2.vcxproj
@@ -266,6 +266,7 @@ xcopy /y /d "$(ProjectDir)Engine\Source\ThirdParty\FBX_SDK\2020.3.7\lib\x64\$(Co
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\Velocity\ParticleModuleVelocity.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Materials\MaterialInterface.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\ParticleEmitterInstance.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\ParticleMeshEmitterInstance.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\ParticleSpriteEmitterInstance.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Skeletal\SkeletalDefine.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\PlayerCameraManager.cpp" />
@@ -540,6 +541,7 @@ xcopy /y /d "$(ProjectDir)Engine\Source\ThirdParty\FBX_SDK\2020.3.7\lib\x64\$(Co
     <ClInclude Include="Engine\Source\Runtime\Engine\Materials\MaterialInterface.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\ParticleEmitterInstance.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\ParticleHelper.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\ParticleMeshEmitterInstance.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\ParticleSpriteEmitterInstance.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Skeletal\SkeletalDefine.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\UserInterface\Debug\DebugViewModeHelpers.h" />

--- a/Week0v2/Week0v2.vcxproj.filters
+++ b/Week0v2/Week0v2.vcxproj.filters
@@ -519,6 +519,11 @@
     <ClInclude Include="Engine\Source\Runtime\Engine\ParticleEmitterInstance.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\ParticleSpriteEmitterInstance.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\RenderPass\ParticleRenderPass.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\Color\ParticleModuleColor.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\Location\ParticleModuleLocation.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\Size\ParticleModuleSize.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\Velocity\ParticleModuleVelocity.h" />
+    <ClInclude Include="Engine\Source\Runtime\Renderer\RenderPass\ParticleMeshRenderPass.h" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Engine\Source\ThirdParty\DirectXTK\Include\DDSTextureLoader.h" />
@@ -598,8 +603,8 @@
     <FxCompile Include="Shaders\FinalVertexShader.hlsl" />
     <FxCompile Include="Shaders\SkeletalUberLitPixelShader.hlsl" />
     <FxCompile Include="Shaders\SkeletalUberLitVertexShader.hlsl" />
-    <FxCompile Include="Shaders\SpriteParticleVertexShader.hlsl" />
-    <FxCompile Include="Shaders\SpriteParticlePixelShader.hlsl" />
+    <FxCompile Include="Shaders\ParticleSpritePixelShader.hlsl" />
+    <FxCompile Include="Shaders\ParticleSpriteVertexShader.hlsl" />
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="Week0v2.natvis" />
@@ -784,8 +789,15 @@
     <ClCompile Include="Engine\Source\Runtime\Engine\ParticleEmitterInstance.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\ParticleSpriteEmitterInstance.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\RenderPass\ParticleRenderPass.cpp" />
-    <ClCompile Include="Shaders\ParticleSpritePixelShader.hlsl" />
-    <ClCompile Include="Shaders\ParticleSpriteVertexShader.hlsl" />
+    <ClCompile Include="Engine\Source\Editor\UnrealEd\EditorPanel.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\Color\ParticleModuleColor.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\Location\ParticleModuleLocation.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\Size\ParticleModuleSize.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\Size\ParticleModuleSizeBase.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\Velocity\ParticleModuleVelocity.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Renderer\RenderPass\ParticleMeshRenderPass.cpp" />
+    <ClCompile Include="Shaders\ParticleMeshPixelShader.hlsl" />
+    <ClCompile Include="Shaders\ParticleMeshVertexShader.hlsl" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Shaders\ShaderHeaders\GConstantBuffers.hlsli" />


### PR DESCRIPTION

### 파티클 시스템 개선 사항:

*   `UParticleEmitter::CreateInstance`에서 기본 `FParticleSpriteEmitterInstance`를 `FParticleMeshEmitterInstance`로 교체하여 메시 기반 파티클 이미터를 활성화했습니다. (`ParticleEmitter.cpp`, [[관련 코드 변경]](diffhunk://#diff-14209ab635720b8e2c5e9d1a7ebbc921e0499abdb015562fdac3a62588a467e4L29-R32))
*   정렬, 재질 업데이트, 인스턴스 드로잉(instanced drawing)을 포함하여 메시 기반 파티클의 렌더링을 처리하는 새로운 메서드 `FDynamicMeshEmitterData::ExecuteRender`를 추가했습니다. (`ParticleSystemRender.cpp`, [[ExecuteRender 구현]](diffhunk://#diff-ff20d63bac3a730442f497b67893ae84500e717a9f8ea599154e257a4e010520R318-R471))
*   파티클의 인스턴스 렌더링을 처리하기 위해 `FParticleEmitterRenderData`에 `DynamicInstanceVertexBuffer`를 도입했습니다. (`ParticleEmitterInstance.h`, [[DynamicInstanceVertexBuffer 추가]](diffhunk://#diff-7e389ae499633aee4faa1cc4012c8f5e51b690abde59f55cd9c37f1ec1e62f81L25-R26))

### 렌더링 데이터 업데이트:

*   컴포넌트 변환과의 더 나은 정렬을 위해 `FDynamicEmitterReplayDataBase`가 `LocalToWorld` 대신 `ComponentLocalToWorld`를 사용하도록 업데이트했습니다. (`ParticleHelper.h`, [[ComponentLocalToWorld 사용]](diffhunk://#diff-5bd44a8f026d39e2fb4f2a40c6e50445bd2f6349c8437cb0f68bb39a59dd26e9L273-R295))
*   미사용 카메라 및 아틀라스 관련 로직을 정리하기 위해 `FDynamicSpriteEmitterData::GetVertexAndIndexData`를 수정했습니다. (`ParticleSystemRender.cpp`, [[미사용 로직 정리 1]](diffhunk://#diff-ff20d63bac3a730442f497b67893ae84500e717a9f8ea599154e257a4e010520L151-L170) [[미사용 로직 정리 2]](diffhunk://#diff-ff20d63bac3a730442f497b67893ae84500e717a9f8ea599154e257a4e010520L201-L207))

### 코드 정리 및 초기화:

*   이미터가 기본적으로 활성화되도록 `UParticleLODLevel`의 `bEnabled` 플래그를 기본적으로 활성화했습니다. (`ParticleLODLevel.h`, [[bEnabled 기본값 변경]](diffhunk://#diff-0c8e3aa1ad123c674327621cd05419dc1fccb72d4e9f37daa276d270bd235341L19-R19))
*   `FParticleEmitterInstance::FillReplayData`에서 `UParticleLODLevel::bEnabled`에 대한 레거시 검사를 제거하여 로직을 단순화했습니다. (`ParticleEmitterInstance.cpp`, [[레거시 bEnabled 체크 제거]](diffhunk://#diff-443a516594ec90585dabb922fcb66515dc8665d425c081f307a6f60df76be319L421-R429))

### 추가 개선 사항:

*   동적 이미터 데이터를 위해 새로운 플래그 `bSelected`를 포함하도록 `FDynamicEmitterDataBase`를 업데이트했습니다. (`ParticleSystemComponent.cpp`, [[bSelected 플래그 추가]](diffhunk://#diff-82be8ded56095b399508e68207f44074be46fd51e138e9f91cc4a021b9cd1c4aR205))
*   스프라이트와 메시 파티클 처리를 통합하기 위해 `FParticleSpriteVertex`에 메시 파티클 인스턴스 데이터 지원을 추가했습니다. (`ParticleHelper.h`, [[메시 파티클 인스턴스 데이터 지원 추가]](diffhunk://#diff-5bd44a8f026d39e2fb4f2a40c6e50445bd2f6349c8437cb0f68bb39a59dd26e9R224-R263))

